### PR TITLE
fix: Add repo info for `@newrelic/rrvideo`

### DIFF
--- a/packages/rrvideo/package.json
+++ b/packages/rrvideo/package.json
@@ -19,6 +19,10 @@
     "prepublish": "yarn build"
   },
   "author": "yanzhen@smartx.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/newrelic-forks/rrweb.git"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Fixes error in Release [step](https://github.com/newrelic-forks/rrweb/actions/runs/23569548006/job/68628876838)

```
🦋  error packages failed to publish:
🦋  @newrelic/rrvideo@1.1.0
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Error: Error: The process '/usr/local/bin/yarn' failed with exit code 1
Error: The process '/usr/local/bin/yarn' failed with exit code 1
```